### PR TITLE
DVB: handle reset pin for demod and tuner

### DIFF
--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_mecool_k5.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_mecool_k5.dts
@@ -23,7 +23,8 @@
 		fe0_ts_out_mode = <1>;
 		fe0_ts  = <1>;
 		fe0_tuner0 = <0>;
-		fe0_tuner1 = <0>;
+		fe0_reset_gpio = <&gpio_ao GPIOAO_10 GPIO_ACTIVE_HIGH>;
+		fe0_reset_value = <0>;
 
 		tuner_num = <1>;
 		tuner0_name = "r848";


### PR DESCRIPTION
Some tv boxes have no pull-up resistors on reset lines so reset lines must be handeled for stable operation (e.g. Mecool K5). This change add generic code for handling reset signals.