### PR TITLE
arm64: dts: amlogic: enable eMMC HS200 by default

### DIFF
--- a/arch/arm64/boot/dts/amlogic/coreelec_common.dtsi
+++ b/arch/arm64/boot/dts/amlogic/coreelec_common.dtsi
@@ -154,6 +154,7 @@
 };
 
 &sd_emmc_c {
+	mmc-hs200-1_8v;
 	/delete-property/ mmc-hs400-1_8v;
 };
 


### PR DESCRIPTION
coreelec_common.dtsi  does not enables HS200 on boards whose eMMC (at least G12B and SM1).
The eMMC therefore tops out at plain high-speed (~50 MB/s) instead of HS200 (~150 MB/s).

Enable HS200 next to the existing HS400 removal so capable eMMCs negotiate HS200 by default.
