### PR TITLE
arm64: dts: amlogic: set HDMI vendor info on vendor-branded boards

### DIFF
--- a/arch/arm64/boot/dts/amlogic/g12a_s905x2_beelink_gt1_mini_2g.dts
+++ b/arch/arm64/boot/dts/amlogic/g12a_s905x2_beelink_gt1_mini_2g.dts
@@ -20,3 +20,10 @@
 		reg = <0x51>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Beelink";
+		product_desc = "GT1-Mini";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12a_s905x2_beelink_gt_mini_a_2g.dts
+++ b/arch/arm64/boot/dts/amlogic/g12a_s905x2_beelink_gt_mini_a_2g.dts
@@ -9,3 +9,10 @@
 		linux,usable-memory = <0x0 0x00100000 0x0 0x7ff00000>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Beelink";
+		product_desc = "GT-Mini-A";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12a_s905x2_mecool_m8s_plus_t2.dts
+++ b/arch/arm64/boot/dts/amlogic/g12a_s905x2_mecool_m8s_plus_t2.dts
@@ -69,3 +69,10 @@
 &demux {
 	status = "okay";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "MECOOL";
+		product_desc = "M8S Plus DVB-T2";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12a_s905y2_radxa_zero.dts
+++ b/arch/arm64/boot/dts/amlogic/g12a_s905y2_radxa_zero.dts
@@ -66,3 +66,10 @@
 		};
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Radxa";
+		product_desc = "Zero";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_a311d_khadas_vim3.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_a311d_khadas_vim3.dts
@@ -113,3 +113,10 @@
 		reg = <0>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Khadas";
+		product_desc = "VIM3";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_a311d_libre_computer_alta.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_a311d_libre_computer_alta.dts
@@ -154,3 +154,10 @@
 &sd_emmc_a {
 	 status = "disabled";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Libre";
+		product_desc = "Alta";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_a311d_radxa_zero2.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_a311d_radxa_zero2.dts
@@ -18,3 +18,10 @@
 &ethmac {
 	status = "disabled";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Radxa";
+		product_desc = "Zero 2";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_s922x_bananapi_m2s.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_s922x_bananapi_m2s.dts
@@ -49,3 +49,10 @@
 &usb3_phy_v2 {
 	portnum = <0>;
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Sinovip";
+		product_desc = "Bananapi-M2S";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_s922x_beelink_gs_king_x.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_s922x_beelink_gs_king_x.dts
@@ -53,3 +53,10 @@
 		};
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Beelink";
+		product_desc = "GS-King X";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_s922x_beelink_gt_king.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_s922x_beelink_gt_king.dts
@@ -31,3 +31,10 @@
 		reg = <0x51>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Beelink";
+		product_desc = "GT-King";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_s922x_minix_u22xj.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_s922x_minix_u22xj.dts
@@ -25,3 +25,10 @@
 		realtek,in2-differential = "false";
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Minix";
+		product_desc = "U22-XJ";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_s922x_minix_u22xj_max.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_s922x_minix_u22xj_max.dts
@@ -136,3 +136,10 @@
 &vddio_c {
 	gpio = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Minix";
+		product_desc = "U22-XJ Max";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_s922x_odroid_n2.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_s922x_odroid_n2.dts
@@ -41,3 +41,10 @@
 		};
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Hardkrn";
+		product_desc = "ODROID-N2";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_s922x_odroid_n2plus.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_s922x_odroid_n2plus.dts
@@ -183,3 +183,10 @@
 &uart_A {
 	status = "disabled";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Hardkrn";
+		product_desc = "ODROID-N2Plus";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_s922x_ugoos_am6_2g.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_s922x_ugoos_am6_2g.dts
@@ -93,3 +93,10 @@
 	/delete-node/ spdifout;
 	/delete-node/ spdifout_a_mute;
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "UGOOS";
+		product_desc = "AM6";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_s922x_ugoos_am6b_2g.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_s922x_ugoos_am6b_2g.dts
@@ -27,3 +27,10 @@
 		aux-det-gpio = <&gpio GPIOH_4 GPIO_ACTIVE_HIGH>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "UGOOS";
+		product_desc = "AM6B+";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/g12b_s922z_amazon_2nd_gen_cube.dts
+++ b/arch/arm64/boot/dts/amlogic/g12b_s922z_amazon_2nd_gen_cube.dts
@@ -516,3 +516,10 @@
 		line-name = "led_controller_power";
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Amazon";
+		product_desc = "Fire TV Cube 2";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s4_s905y4_buzztv_hd5_2g.dts
+++ b/arch/arm64/boot/dts/amlogic/s4_s905y4_buzztv_hd5_2g.dts
@@ -36,3 +36,10 @@
 &sd_emmc_b {
 	status = "disabled";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "BuzzTV";
+		product_desc = "HD5";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s4_s905y4_khadas_vim1s.dts
+++ b/arch/arm64/boot/dts/amlogic/s4_s905y4_khadas_vim1s.dts
@@ -104,3 +104,10 @@
 		};
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Khadas";
+		product_desc = "VIM1S";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s5_s928x_minix_u8k_ultra.dts
+++ b/arch/arm64/boot/dts/amlogic/s5_s928x_minix_u8k_ultra.dts
@@ -45,3 +45,10 @@
 &vrtc {
 	status = "disabled";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Minix";
+		product_desc = "U8K-Ultra";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s5_s928x_tencent_aurora_5x.dts
+++ b/arch/arm64/boot/dts/amlogic/s5_s928x_tencent_aurora_5x.dts
@@ -49,3 +49,10 @@
 		};
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Tencent";
+		product_desc = "Aurora Box 5X";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s5_s928x_ugoos_am8_4g.dts
+++ b/arch/arm64/boot/dts/amlogic/s5_s928x_ugoos_am8_4g.dts
@@ -259,3 +259,10 @@
 		};
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Ugoos";
+		product_desc = "AM8";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s5_s928x_ugoos_am8_8g.dts
+++ b/arch/arm64/boot/dts/amlogic/s5_s928x_ugoos_am8_8g.dts
@@ -10,3 +10,10 @@
 					0x00000001 0x00000000 0x00000001 0x20000000>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Ugoos";
+		product_desc = "AM8 Pro";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s5_s928x_ugoos_sk1_8g.dts
+++ b/arch/arm64/boot/dts/amlogic/s5_s928x_ugoos_sk1_8g.dts
@@ -40,3 +40,10 @@
 		};
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Ugoos";
+		product_desc = "SK1";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s5_s928x_x96_x10_4g.dts
+++ b/arch/arm64/boot/dts/amlogic/s5_s928x_x96_x10_4g.dts
@@ -23,3 +23,10 @@
 &i2c1 {
 	status = "disabled";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "X96";
+		product_desc = "X10";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s5_s928x_x96_x10_8g.dts
+++ b/arch/arm64/boot/dts/amlogic/s5_s928x_x96_x10_8g.dts
@@ -10,3 +10,10 @@
 					0x00000001 0x00000000 0x00000001 0x20000000>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "X96";
+		product_desc = "X10 Pro";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s6_s905x5_ugoos_am9.dts
+++ b/arch/arm64/boot/dts/amlogic/s6_s905x5_ugoos_am9.dts
@@ -298,3 +298,10 @@
 &uart_C {
 	status = "okay";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Ugoos";
+		product_desc = "AM9";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s6_s905x5_ugoos_am9_pro.dts
+++ b/arch/arm64/boot/dts/amlogic/s6_s905x5_ugoos_am9_pro.dts
@@ -9,3 +9,10 @@
 		mosi-gpios = <&gpio GPIOA_9 GPIO_ACTIVE_LOW>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Ugoos";
+		product_desc = "AM9 Pro";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s7d_s905x5m_odroid_c5.dts
+++ b/arch/arm64/boot/dts/amlogic/s7d_s905x5m_odroid_c5.dts
@@ -208,3 +208,10 @@
 	pinctrl-0 = <&i2c4_pins2>;
 	clock-frequency = <100000>;		/* default 100k */
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Hardkrn";
+		product_desc = "ODROID-C5";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s7d_s905x5m_ugoos_sk4.dts
+++ b/arch/arm64/boot/dts/amlogic/s7d_s905x5m_ugoos_sk4.dts
@@ -166,3 +166,10 @@
 		      0xe718ff00 IR_NORMAL KEY_POWER
 		      0x8b74e619 IR_NORMAL KEY_POWER>;
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Ugoos";
+		product_desc = "SK4";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s7d_s905x5m_ugoos_x5m_pro.dts
+++ b/arch/arm64/boot/dts/amlogic/s7d_s905x5m_ugoos_x5m_pro.dts
@@ -192,3 +192,10 @@
 	vmmc-supply = <&sdcard_3v3>;
 	vqmmc-supply = <&vddio_c>;
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Ugoos";
+		product_desc = "X5M Pro";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/s7d_s905x5m_xiaomi_3rd_gen.dts
+++ b/arch/arm64/boot/dts/amlogic/s7d_s905x5m_xiaomi_3rd_gen.dts
@@ -55,3 +55,10 @@
 &sd_emmc_b {
 	status = "disabled";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Xiaomi";
+		product_desc = "3rd Gen";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sc2_s905x4_buzztv_u5_4g_1gbit.dts
+++ b/arch/arm64/boot/dts/amlogic/sc2_s905x4_buzztv_u5_4g_1gbit.dts
@@ -5,3 +5,10 @@
 	amlogic-dt-id = "sc2_s905x4_ah212-gEth-4g";
 	coreelec-dt-id = "sc2_s905x4_buzztv_u5_4g_1gbit";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "BuzzTV";
+		product_desc = "U5";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sc2_s905x4_buzztv_x5_2g.dts
+++ b/arch/arm64/boot/dts/amlogic/sc2_s905x4_buzztv_x5_2g.dts
@@ -57,3 +57,10 @@
 &ethmac {
 	cali_val = <0x80000>;
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "BuzzTV";
+		product_desc = "X5";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sc2_s905x4_mecool_kt1.dts
+++ b/arch/arm64/boot/dts/amlogic/sc2_s905x4_mecool_kt1.dts
@@ -75,3 +75,10 @@
 &sd_emmc_b {
 	max-frequency = <150000000>;
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Mecool";
+		product_desc = "KT1";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sc2_s905x4_mecool_kt1_s2x.dts
+++ b/arch/arm64/boot/dts/amlogic/sc2_s905x4_mecool_kt1_s2x.dts
@@ -67,3 +67,10 @@
 &sd_emmc_b {
 	max-frequency = <150000000>;
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Mecool";
+		product_desc = "KT1";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sc2_s905x4_sei_smb_280_id5.dts
+++ b/arch/arm64/boot/dts/amlogic/sc2_s905x4_sei_smb_280_id5.dts
@@ -103,3 +103,10 @@
 		};
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Homatic";
+		product_desc = "R 4K Plus";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sc2_s905x4_sei_smb_280_id7.dts
+++ b/arch/arm64/boot/dts/amlogic/sc2_s905x4_sei_smb_280_id7.dts
@@ -37,3 +37,10 @@
 		reset-deassert-us = <300000>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "RockTek";
+		product_desc = "G2";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sc2_s905x4_ugoos_am7.dts
+++ b/arch/arm64/boot/dts/amlogic/sc2_s905x4_ugoos_am7.dts
@@ -231,3 +231,10 @@
 		def-dacvol = <0x0a>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Ugoos";
+		product_desc = "AM7";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sc2_s905x4_ugoos_x4.dts
+++ b/arch/arm64/boot/dts/amlogic/sc2_s905x4_ugoos_x4.dts
@@ -86,3 +86,10 @@
 &sd_emmc_b {
 	status = "okay";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Ugoos";
+		product_desc = "X4";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sc2_s905x4_x96_x4_2g.dts
+++ b/arch/arm64/boot/dts/amlogic/sc2_s905x4_x96_x4_2g.dts
@@ -51,3 +51,10 @@
 	bt_en-gpios = <&gpio    GPIOX_17 GPIO_ACTIVE_HIGH>;
 	hostwake-gpios = <&gpio GPIOX_19 GPIO_ACTIVE_HIGH>;
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "X96";
+		product_desc = "X4";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905d3_khadas_vim3l.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905d3_khadas_vim3l.dts
@@ -173,3 +173,10 @@
 		reg = <0>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Khadas";
+		product_desc = "VIM3L";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905d3_libre_computer_solitude.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905d3_libre_computer_solitude.dts
@@ -135,3 +135,10 @@
 &sd_emmc_a {
 	 status = "disabled";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Libre";
+		product_desc = "Solitude";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_bananapi_m2pro.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_bananapi_m2pro.dts
@@ -9,3 +9,10 @@
 		linux,usable-memory = <0x0 0x000000 0x0 0x80000000>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Sinovip";
+		product_desc = "Bananapi-M2Pro";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_bananapi_m5.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_bananapi_m5.dts
@@ -128,3 +128,10 @@
 &sd_emmc_a {
 	 status = "disabled";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Sinovip";
+		product_desc = "Bananapi-M5";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_beelink_gt1mini2_2g.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_beelink_gt1mini2_2g.dts
@@ -5,3 +5,10 @@
 	coreelec-dt-id = "sm1_s905x3_beelink_gt1mini2_2g";
 	amlogic-dt-id = "sm1_ac213_2g";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Beelink";
+		product_desc = "GT1-Mini-2";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_beelink_gt1mini2_4g.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_beelink_gt1mini2_4g.dts
@@ -5,3 +5,10 @@
 	coreelec-dt-id = "sm1_s905x3_beelink_gt1mini2_4g";
 	amlogic-dt-id = "sm1_ac213_4g";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Beelink";
+		product_desc = "GT1-Mini-2";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_buzztv_xrs4500.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_buzztv_xrs4500.dts
@@ -67,3 +67,10 @@
 		max-frequency = <170000000>;
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "BuzzTV";
+		product_desc = "XRS4500";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_gtcombo.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_gtcombo.dts
@@ -108,3 +108,10 @@
 		};
 	};
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "GTMedia";
+		product_desc = "GT Combo";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_magicsee_c500_pro_2g.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_magicsee_c500_pro_2g.dts
@@ -67,3 +67,10 @@
 &demux {
 	status = "okay";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Magic";
+		product_desc = "C500 Pro";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_magicsee_c500_pro_4g.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_magicsee_c500_pro_4g.dts
@@ -67,3 +67,10 @@
 &demux {
 	status = "okay";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Magic";
+		product_desc = "C500 Pro";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_mecool_k5.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_mecool_k5.dts
@@ -45,3 +45,10 @@
 &demux {
 	status = "okay";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Mecool";
+		product_desc = "K5";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_odroid_c4.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_odroid_c4.dts
@@ -139,3 +139,10 @@
 &sd_emmc_a {
 	 status = "disabled";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Hardkrn";
+		product_desc = "ODROID-C4";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_starnet_apple_x3.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_starnet_apple_x3.dts
@@ -33,3 +33,10 @@
 &demux {
 	status = "okay";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "StarNet";
+		product_desc = "Apple-X3";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/sm1_s905x3_tiger_1b.dts
+++ b/arch/arm64/boot/dts/amlogic/sm1_s905x3_tiger_1b.dts
@@ -33,3 +33,10 @@
 &demux {
 	status = "okay";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Tiger";
+		product_desc = "One Billion";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/t7_a311d2_beelink_gt_king_ii_4g.dts
+++ b/arch/arm64/boot/dts/amlogic/t7_a311d2_beelink_gt_king_ii_4g.dts
@@ -32,3 +32,10 @@
 	phy-handle = <&external_phy>;
 	amlogic,tx-delay-ns = <2>;
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Beelink";
+		product_desc = "GT-King II";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/t7_a311d2_khadas_vim4.dts
+++ b/arch/arm64/boot/dts/amlogic/t7_a311d2_khadas_vim4.dts
@@ -7,3 +7,10 @@
 	coreelec-dt-id = "t7_a311d2_khadas_vim4";
 	amlogic-dt-id = "t7_a311d2_an400-8g";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Khadas";
+		product_desc = "VIM4";
+	};
+};

--- a/arch/arm64/boot/dts/amlogic/t7c_a311d2_khadas_vim4n.dts
+++ b/arch/arm64/boot/dts/amlogic/t7c_a311d2_khadas_vim4n.dts
@@ -7,3 +7,10 @@
 	coreelec-dt-id = "t7c_a311d2_khadas_vim4n";
 	amlogic-dt-id = "t7c_a311d2_an400-8g";
 };
+
+&amhdmitx {
+	vend_data {
+		vendor_name = "Khadas";
+		product_desc = "VIM4N";
+	};
+};


### PR DESCRIPTION
The shared coreelec_g12b_common.dtsi sets the amhdmitx vend_data product_desc to "G12B" with the comment "Should modified by Customer". That generic SoC-family string is what AVRs and TVs display in their HDMI source / input list when they read the HDMI Vendor-Specific InfoFrame from the box.

Override the board's vend_data so the broadcast identifier matches the actual product instead of the generic SoC name.

Before:
  $ cat /sys/firmware/devicetree/base/amhdmitx/vend_data/vendor_name
  Amlogic
  $ cat /sys/firmware/devicetree/base/amhdmitx/vend_data/product_desc
  G12B          # AVR shows "G12B"

After:
  vendor_name = UGOOS
  product_desc = AM6B+    # AVR shows "AM6B+"

This for all "G12B" variants hopefully.