### PR TITLE
meson_hdmi: fix 24.00 / 23.976 frame rate mismatch

### DIFF
--- a/drivers/drm/meson_hdmi.c
+++ b/drivers/drm/meson_hdmi.c
@@ -1907,7 +1907,7 @@ void meson_hdmitx_encoder_atomic_mode_set(struct drm_encoder *encoder,
 		convert_attrstr(attr_debugfs, attr);
 		ret = hdmitx_common_build_format_para(tx_comm,
 					&hdmitx_state->hcs.para, vic,
-					tx_comm->frac_rate_policy,
+					hdmitx_state->frac_rate_policy,
 					attr->colorformat,
 					bitdepth_to_colordepth(attr->bitdepth),
 					HDMI_QUANTIZATION_RANGE_FULL);
@@ -1952,7 +1952,7 @@ void meson_hdmitx_encoder_atomic_mode_set(struct drm_encoder *encoder,
 	}
 
 	ret = hdmitx_common_build_format_para(tx_comm, &hdmitx_state->hcs.para,
-					      vic, tx_comm->frac_rate_policy,
+					      vic, hdmitx_state->frac_rate_policy,
 					      attr->colorformat,
 					      bitdepth_to_colordepth(attr->bitdepth),
 					      HDMI_QUANTIZATION_RANGE_FULL);


### PR DESCRIPTION
 **Problem**
When an HDMI atomic commit changes only the fractional-rate policy — e.g. switching between 24.000Hz and 23.976Hz, which share the same VIC mode (2160p24hz) — the output keeps running at the previous rate.

meson_hdmitx_encoder_atomic_mode_set() builds the timing parameters from tx_comm->frac_rate_policy (the current value) instead of hdmitx_state->frac_rate_policy (the value being committed). The committed value is only copied into tx_comm later in the commit, after the timing has already been built and the hardware programmed — so the output stays at the old rate.

**Fixes**
1. This PR: Build the timing from the committed value at both hdmitx_common_build_format_para() call sites, so the correct rate is programmed in the same commit.

2. In Kodi, also commit the changes at the same time with a patch like that:
```
diff --git a/xbmc/windowing/amlogic/AMLDisplay.cpp b/xbmc/windowing/amlogic/AMLDisplay.cpp
index 56dcfaef3c..7084382536 100644
--- a/xbmc/windowing/amlogic/AMLDisplay.cpp
+++ b/xbmc/windowing/amlogic/AMLDisplay.cpp
@@ -494,7 +494,7 @@ std::string CAMLDRMUtils::aml_get_drmDevice_modes(void)
 
 // set mode of drmDevice
 bool CAMLDRMUtils::aml_set_drmDevice_mode(const RESOLUTION_INFO &res, std::string mode,
-  std::string framebuffer_name, bool force_mode_switch)
+  std::string framebuffer_name, bool force_mode_switch, int frac_rate_policy)
 {
   bool ret = false;
 
@@ -523,7 +523,7 @@ bool CAMLDRMUtils::aml_set_drmDevice_mode(const RESOLUTION_INFO &res, std::strin
     return ret;
   }
 
-  ret = aml_set_drmDevice_active(mode, true);
+  ret = aml_set_drmDevice_active(mode, true, frac_rate_policy);
 
   if (!ret && force_mode_switch)
     set_drmProp(m_connector->connector_id, "UPDATE", DRM_MODE_OBJECT_CONNECTOR, 1, NULL);
@@ -722,12 +722,25 @@ std::string CAMLDRMUtils::aml_get_drmDevice_preferred_mode()
   return mode;
 }
 
-bool CAMLDRMUtils::aml_set_drmDevice_active(std::string mode, bool active)
+bool CAMLDRMUtils::aml_set_drmDevice_active(std::string mode, bool active, int frac_rate_policy)
 {
   bool ret = false;
   drmModeModeInfoPtr drmDevicemode = NULL;
 
-  if (!StringUtils::EqualsNoCase(aml_get_drmDevice_mode(), mode))
+  // Two HDMI mode variants share the same VIC mode-name string for
+  // integer-vs-fractional cinema rates (e.g. "2160p24hz" covers both
+  // 24.000Hz and 23.976Hz; the wire rate is selected by FRAC_RATE_POLICY).
+  // The legacy "skip if mode name unchanged" early-out misses these
+  // transitions, leaving the wire at the previously committed rate.
+  //
+  // Always force the atomic commit when the caller passed a frac_rate_policy:
+  // the kernel keeps frac_rate_policy in two separate state vars (hdmitx_state
+  // read via DRM property, vs tx_comm that drives the wire rate computation)
+  // which only get synced inside an atomic commit. A pre-commit DRM-property
+  // read can therefore report the new value while the wire and tx_comm are
+  // still at the old rate, defeating any "skip if no change" check.
+  bool force_for_frac = (frac_rate_policy >= 0);
+  if (force_for_frac || !StringUtils::EqualsNoCase(aml_get_drmDevice_mode(), mode))
   {
     for (int i = 0; i < m_connector->count_modes; i++)
     {
@@ -755,6 +768,11 @@ bool CAMLDRMUtils::aml_set_drmDevice_active(std::string mode, bool active)
       set_drmProp(m_crtc->crtc_id, "MODE_ID", DRM_MODE_OBJECT_CRTC, mode_blobid, req);
       set_drmProp(m_crtc->crtc_id, "ACTIVE", DRM_MODE_OBJECT_CRTC, active ? 1 : 0, req);
 
+      // Same-atomic-commit FRAC_RATE_POLICY so the wire actually re-syncs
+      // when only the cinema rate variant changes (24.000 <-> 23.976).
+      if (frac_rate_policy >= 0)
+        set_drmProp(m_connector->connector_id, "FRAC_RATE_POLICY", DRM_MODE_OBJECT_CONNECTOR, frac_rate_policy, req);
+
       ret = (drmModeAtomicCommit(m_fd, req, DRM_MODE_ATOMIC_ALLOW_MODESET, NULL) == 0);
       if (!ret)
         CLog::Log(LOGDEBUG, "CAMLDRMUtils::{} - failed to set drmDevice mode: {}", __FUNCTION__, drmDevicemode->name);
@@ -908,10 +926,11 @@ bool CAMLDisplay::set_display_resolution(const RESOLUTION_INFO &res, std::string
 
   int fractional_rate = (res.fRefreshRate == floor(res.fRefreshRate)) ? 0 : 1;
 
-  if (m_amlDRMUtils->aml_get_drmProperty("FRAC_RATE_POLICY", DRM_MODE_OBJECT_CONNECTOR) != fractional_rate)
-    m_amlDRMUtils->aml_set_drmProperty("FRAC_RATE_POLICY", DRM_MODE_OBJECT_CONNECTOR, fractional_rate);
-
-  m_amlDRMUtils->aml_set_drmDevice_mode(res, mode, framebuffer_name, force_mode_switch);
+  // Pass FRAC_RATE_POLICY through to land in the same atomic commit as the
+  // mode-set (see CAMLDRMUtils::aml_set_drmDevice_active). Setting it via
+  // legacy drmModeObjectSetProperty does not flush to the wire when the
+  // mode name is unchanged (same-VIC integer<->fractional transitions).
+  m_amlDRMUtils->aml_set_drmDevice_mode(res, mode, framebuffer_name, force_mode_switch, fractional_rate);
 
   return true;
 }
diff --git a/xbmc/windowing/amlogic/AMLDisplay.h b/xbmc/windowing/amlogic/AMLDisplay.h
index 662a3bbb4b..b23977f10c 100644
--- a/xbmc/windowing/amlogic/AMLDisplay.h
+++ b/xbmc/windowing/amlogic/AMLDisplay.h
@@ -87,12 +87,12 @@ public:
   std::string aml_get_drmDevice_mode();
   std::string aml_get_drmDevice_modes();
   bool aml_set_drmDevice_mode(const RESOLUTION_INFO &res, std::string mode,
-    std::string framebuffer_name, bool force_mode_switch);
+    std::string framebuffer_name, bool force_mode_switch, int frac_rate_policy = -1);
   int aml_get_drmProperty(std::string name, unsigned int obj_type);
   void aml_set_drmProperty(std::string name, unsigned int obj_type, unsigned int value);
   int aml_get_drmDevice_modes_count(drmModeConnection *connection);
   std::string aml_get_drmDevice_preferred_mode();
-  bool aml_set_drmDevice_active(std::string mode, bool active);
+  bool aml_set_drmDevice_active(std::string mode, bool active, int frac_rate_policy = -1);
   bool aml_get_drmDevice_connected() const { return m_connection == DRM_MODE_CONNECTED; }
   void FlipPage(uint32_t fb_id, bool async);
 
```

Happy to create the follow-up CoreELEC/kodi PR if you like the approach.