### PR TITLE
Dolby Vision teardown / VSIF / metadata-buffer fixes

### DIFF
--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -6835,6 +6835,14 @@ static bool send_hdmi_pkt
 	bool dovi_ll_enable = false;
 	bool diagnostic_enable = false;
 
+	if (dst_format == FORMAT_DOVI &&
+	    !dolby_vision_on &&
+	    amdv_target_mode == AMDV_OUTPUT_MODE_BYPASS &&
+	    dolby_vision_status == BYPASS_PROCESS) {
+		dolby_vision_flags &= ~FLAG_FORCE_HDMI_PKT;
+		return false;
+	}
+
 	if ((debug_dolby & 2))
 		pr_dv_dbg("[%s]src_format %d,dst %d,last %d:,vf %p\n",
 			     __func__, src_format, dst_format,
@@ -7246,6 +7254,11 @@ static void send_hdmi_pkt_ahead
 {
 	bool dovi_ll_enable = false;
 	bool diagnostic_enable = false;
+
+	if (!dolby_vision_on &&
+	    amdv_target_mode == AMDV_OUTPUT_MODE_BYPASS &&
+	    dolby_vision_status == BYPASS_PROCESS)
+		return;
 
 	if ((dolby_vision_flags & FLAG_FORCE_DV_LL) ||
 	    dolby_vision_ll_policy == DOLBY_VISION_LL_YUV422 ||

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -10564,7 +10564,7 @@ int amdv_parse_metadata_v2_stb(struct vframe_s *vf,
 #define CORE_META_LENGTH 512
 
 static unsigned char reversed_meta_buffer[CORE_META_LENGTH];
-static unsigned char combo_meta_buffer[CORE_META_LENGTH];
+static unsigned char combo_meta_buffer[MD_BUF_SIZE];
 
 static size_t reverse_dv_meta(
 	unsigned char *metadata,

--- a/drivers/media/enhancement/amdolby_vision/amdv_hw.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv_hw.c
@@ -6453,6 +6453,12 @@ void enable_amdv(int enable)
 	} else {
 		enable_amdv_v1(enable);
 	}
+
+	if (!enable) {
+		if (dolby_vision_flags & FLAG_TOGGLE_FRAME)
+			pr_dv_dbg("clear stale TOGGLE_FRAME at DV teardown (bypass path missed gated clear)\n");
+		dolby_vision_flags &= ~FLAG_TOGGLE_FRAME;
+	}
 }
 
 void update_stb_core_setting_flag(int flag)


### PR DESCRIPTION
Three independent Dolby Vision fixes in amdolby_vision, each addressing real playback failure (observed on G12B / AM6B+). 

1. amdv: clear stale FLAG_TOGGLE_FRAME at DV teardown (amdv_hw.c)
Stopping a DV video or switching resolution out of DV can leave FLAG_TOGGLE_FRAME set; the next DV start toggles on the first frame before any DV metadata exists resulting in black frame, and some AVRs drop the HDMI link until next resolution change. The quick-exit paths (HLG/HDR10+/CUVA/ large metadata) skip the worker that normally clears it. Clear it once in enable_amdv() on the off transition - every teardown path funnels through there.
     
2. amdv: suppress DV VSIF emit only when DV is fully off (amdv.c)
After a DV video stops, the worker can re-send a DV HDMI packet using the last frame's cached format while DV is already off, so the sink sees DV signalling flip on/off frame-to-frame. Suppress the emit only when every layer agrees DV is down (!dolby_vision_on, target and status both BYPASS) - never mid-transition, so a legitimate DV->SDR switch is untouched.

3. amdv: size combo_meta_buffer to source md_buf to fix overflow (amdv.c)
Some DV streams carry >512 bytes of metadata/frame; source_meta_copy() assembles it in a 512-byte scratch buffer and a larger frame overruns into neighbouring DV state the proprietary library reads back, trippingits stack check and crashing randomly.
Size the scratch buffer to MD_BUF_SIZE to match its source.