### PR TITLE
amdolby_vision: fix Dolby Vision crashes and a seek glitch

### DIFF
--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -5900,7 +5900,7 @@ int parse_sei_and_meta_ext_v2(struct vframe_s *vf,
 				}
 			}
 			/* prepare metadata parser */
-			if (!dv_inst[dv_id].metadata_parser) {
+			if (!rcu_access_pointer(dv_inst[dv_id].metadata_parser)) {
 				pr_dv_error
 				("[inst%d]meta(%d), pts(%lld) -> metadata parser init fail\n",
 					dv_id + 1, rpu_size, vf->pts_us64);
@@ -6112,7 +6112,7 @@ int parse_sei_and_meta_ext_v2(struct vframe_s *vf,
 				}
 			}
 			/* prepare metadata parser */
-			if (!dv_inst[dv_id].metadata_parser) {
+			if (!rcu_access_pointer(dv_inst[dv_id].metadata_parser)) {
 				pr_dv_error
 				("meta(%d), pts(%lld) -> metadata parser init fail\n",
 				size, vf->pts_us64);

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -2556,13 +2556,15 @@ int dv_inst_map(int *inst)
 		dv_inst[*inst].layer_id = VD_PATH_MAX;
 		dv_inst[*inst].video_height = 0;
 		dv_inst[*inst].video_width = 0;
-		dv_inst[*inst].src_format = FORMAT_SDR;
 		dv_inst[*inst].valid = 0;
 		dv_inst[*inst].current_id = 0;
-		dv_inst[*inst].in_md = NULL;
-		dv_inst[*inst].in_md_size = 0;
-		dv_inst[*inst].in_comp = NULL;
-		dv_inst[*inst].in_comp_size = 0;
+		/* size-before-pointer release: in_md==NULL implies in_md_size==0 */
+		WRITE_ONCE(dv_inst[*inst].src_format, FORMAT_SDR);
+		WRITE_ONCE(dv_inst[*inst].in_md_size, 0);
+		WRITE_ONCE(dv_inst[*inst].in_comp_size, 0);
+		smp_wmb();
+		WRITE_ONCE(dv_inst[*inst].in_md, NULL);
+		WRITE_ONCE(dv_inst[*inst].in_comp, NULL);
 		dv_inst[*inst].err_parse_cnt = 0;
 		return 0;
 	}
@@ -2627,8 +2629,8 @@ void force_unmap_all_inst(void)
 		if (snapshots[i] && p_funcs_stb)
 			p_funcs_stb->multi_mp_release(&snapshots[i]);
 	}
-	mutex_unlock(&dv_inst_lock);
-
+	/* hold dv_inst_lock across the field clears too, so a concurrent
+	 * dv_inst_map() cannot re-map and have its fresh fields clobbered */
 	for (i = 0; i < NUM_INST; i++) {
 		amdv_clear_buf(i);
 		dv_inst[i].frame_count = 0;
@@ -2638,15 +2640,18 @@ void force_unmap_all_inst(void)
 		dv_inst[i].layer_id = VD_PATH_MAX;
 		dv_inst[i].video_height = 0;
 		dv_inst[i].video_width = 0;
-		dv_inst[i].src_format = FORMAT_INVALID;
 		dv_inst[i].amdv_src_format = 0;
 		dv_inst[i].valid = 0;
 		dv_inst[i].current_id = 0;
-		dv_inst[i].in_md = NULL;
-		dv_inst[i].in_md_size = 0;
-		dv_inst[i].in_comp = NULL;
-		dv_inst[i].in_comp_size = 0;
+		/* size-before-pointer release (see dv_inst_map) */
+		WRITE_ONCE(dv_inst[i].src_format, FORMAT_INVALID);
+		WRITE_ONCE(dv_inst[i].in_md_size, 0);
+		WRITE_ONCE(dv_inst[i].in_comp_size, 0);
+		smp_wmb();
+		WRITE_ONCE(dv_inst[i].in_md, NULL);
+		WRITE_ONCE(dv_inst[i].in_comp, NULL);
 	}
+	mutex_unlock(&dv_inst_lock);
 }
 
 #define MAX_FILENAME_LENGTH 64
@@ -10477,19 +10482,20 @@ int amdv_parse_metadata_v2_stb(struct vframe_s *vf,
 	}
 
 	if (vf && dv_inst_valid(dv_id)) {
-		dv_inst[dv_id].in_md =
-			dv_inst[dv_id].md_buf[dv_inst[dv_id].current_id];
-		dv_inst[dv_id].in_comp =
-			dv_inst[dv_id].comp_buf[dv_inst[dv_id].current_id];
+		WRITE_ONCE(dv_inst[dv_id].in_md,
+			dv_inst[dv_id].md_buf[dv_inst[dv_id].current_id]);
+		WRITE_ONCE(dv_inst[dv_id].in_comp,
+			dv_inst[dv_id].comp_buf[dv_inst[dv_id].current_id]);
 		if (src_format == FORMAT_DOVI) {
-			dv_inst[dv_id].in_md_size = total_md_size;
-			dv_inst[dv_id].in_comp_size = total_comp_size;
+			WRITE_ONCE(dv_inst[dv_id].in_md_size, total_md_size);
+			WRITE_ONCE(dv_inst[dv_id].in_comp_size, total_comp_size);
 		} else {
-			dv_inst[dv_id].in_md_size = 0;
-			dv_inst[dv_id].in_comp_size = 0;
+			WRITE_ONCE(dv_inst[dv_id].in_md_size, 0);
+			WRITE_ONCE(dv_inst[dv_id].in_comp_size, 0);
 		}
 
-		dv_inst[dv_id].src_format = src_format;
+		smp_wmb(); /* release: publish src_format after in_md/size */
+		WRITE_ONCE(dv_inst[dv_id].src_format, src_format);
 		dv_inst[dv_id].set_chroma_format = CP_P420;
 		/*input yuv range for non-dv source*/
 		dv_inst[dv_id].set_yuv_range = is_fullrange_frame(vf) ?
@@ -10823,7 +10829,8 @@ int amdv_control_path(struct vframe_s *vf, struct vframe_s *vf_2,
 		if (dv_inst_valid(id)) {
 			dv_inst[id].valid = 1;
 			input_mode = dv_inst[id].input_mode;
-			src_format = dv_inst[id].src_format;
+			/* single snapshot, reused for the gate and the blob value */
+			src_format = READ_ONCE(dv_inst[id].src_format);
 
 			if (new_m_dovi_setting.input[i].video_width &&
 			    new_m_dovi_setting.input[i].video_height) {
@@ -10883,19 +10890,26 @@ int amdv_control_path(struct vframe_s *vf, struct vframe_s *vf_2,
 			new_m_dovi_setting.input[i].input_mode = dv_inst[id].input_mode;
 			new_m_dovi_setting.input[i].video_width = dv_inst[id].video_width;
 			new_m_dovi_setting.input[i].video_height = dv_inst[id].video_height;
+			smp_rmb(); /* acquire: pair with writer's src_format release */
 			new_m_dovi_setting.input[i].in_md =
-				dv_inst[id].in_md;
+				READ_ONCE(dv_inst[id].in_md);
 			new_m_dovi_setting.input[i].in_comp =
-				dv_inst[id].in_comp;
+				READ_ONCE(dv_inst[id].in_comp);
 
+			smp_rmb(); /* acquire: in_md before in_md_size */
 			if (src_format == FORMAT_DOVI) {
-				new_m_dovi_setting.input[i].in_md_size = dv_inst[id].in_md_size;
-				new_m_dovi_setting.input[i].in_comp_size = dv_inst[id].in_comp_size;
+				new_m_dovi_setting.input[i].in_md_size = READ_ONCE(dv_inst[id].in_md_size);
+				new_m_dovi_setting.input[i].in_comp_size = READ_ONCE(dv_inst[id].in_comp_size);
 			} else {
 				new_m_dovi_setting.input[i].in_md_size = 0;
 				new_m_dovi_setting.input[i].in_comp_size = 0;
 			}
-			new_m_dovi_setting.input[i].src_format = dv_inst[id].src_format;
+			new_m_dovi_setting.input[i].src_format = src_format;
+			/* never hand the blob NULL in_md with positive size */
+			if (!new_m_dovi_setting.input[i].in_md)
+				new_m_dovi_setting.input[i].in_md_size = 0;
+			if (!new_m_dovi_setting.input[i].in_comp)
+				new_m_dovi_setting.input[i].in_comp_size = 0;
 			new_m_dovi_setting.input[i].p_hdr10_param = &dv_inst[id].hdr10_param;
 			new_m_dovi_setting.input[i].set_chroma_format =
 				dv_inst[id].set_chroma_format;

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -2516,6 +2516,20 @@ int dv_inst_map(int *inst)
 		dv_inst[new_map_id].mapped = true;
 		*inst = new_map_id;
 
+		{
+			/* registration pre-inits inst 0/1: tear a pre-existing parser
+			 * down via RCU (never reset a reader-visible one in place) so
+			 * the init below always sees a NULL slot. */
+			void *stale = rcu_dereference_protected(
+				dv_inst[*inst].metadata_parser,
+				lockdep_is_held(&dv_inst_lock));
+			if (stale && p_funcs_stb) {
+				rcu_assign_pointer(dv_inst[*inst].metadata_parser, NULL);
+				synchronize_rcu();
+				p_funcs_stb->multi_mp_release(&stale);
+			}
+		}
+
 		if (!rcu_dereference_protected(dv_inst[*inst].metadata_parser,
 					       lockdep_is_held(&dv_inst_lock)) &&
 		    p_funcs_stb) {
@@ -2523,18 +2537,14 @@ int dv_inst_map(int *inst)
 				p_funcs_stb->multi_mp_init(dolby_vision_flags
 								& FLAG_CHANGE_SEQ_HEAD
 								? 1 : 0);
-			/* publish to vsync readers via RCU */
-			rcu_assign_pointer(dv_inst[*inst].metadata_parser,
-					   new_parser);
-		}
-		{
-			void *mp = rcu_dereference_protected
-				(dv_inst[*inst].metadata_parser,
-				 lockdep_is_held(&dv_inst_lock));
-			if (mp) {
-				p_funcs_stb->multi_mp_reset(mp, 1);
+			/* reset before publishing: never expose a half-reset parser
+			 * to a concurrent vsync multi_mp_process(). */
+			if (new_parser) {
+				p_funcs_stb->multi_mp_reset(new_parser, 1);
 				pr_dv_dbg("reset mp\n");
 			}
+			rcu_assign_pointer(dv_inst[*inst].metadata_parser,
+					   new_parser);
 		}
 		mutex_unlock(&dv_inst_lock);
 		/*clear dv_vf and framecount*/
@@ -2596,13 +2606,31 @@ EXPORT_SYMBOL(dv_inst_unmap);
 void force_unmap_all_inst(void)
 {
 	int i;
+	void *snapshots[NUM_INST] = { NULL };
 
 	if (!multi_dv_mode)
 		return;
 
+	/* two-pass RCU teardown (see dv_inst_unmap): NULL under lock, one
+	 * synchronize_rcu, then release -- also plugs a parser leak here. */
+	mutex_lock(&dv_inst_lock);
+	for (i = 0; i < NUM_INST; i++) {
+		snapshots[i] = rcu_dereference_protected
+			(dv_inst[i].metadata_parser,
+			 lockdep_is_held(&dv_inst_lock));
+		if (snapshots[i])
+			rcu_assign_pointer(dv_inst[i].metadata_parser, NULL);
+		dv_inst[i].mapped = 0;
+	}
+	synchronize_rcu();
+	for (i = 0; i < NUM_INST; i++) {
+		if (snapshots[i] && p_funcs_stb)
+			p_funcs_stb->multi_mp_release(&snapshots[i]);
+	}
+	mutex_unlock(&dv_inst_lock);
+
 	for (i = 0; i < NUM_INST; i++) {
 		amdv_clear_buf(i);
-		dv_inst[i].mapped = 0;
 		dv_inst[i].frame_count = 0;
 		dv_inst[i].last_mel_mode = 0;
 		dv_inst[i].last_total_md_size = 0;

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -14,6 +14,7 @@
 #include <linux/errno.h>
 #include <linux/dma-mapping.h>
 #include <linux/platform_device.h>
+#include <linux/rcupdate.h>
 #include <linux/amlogic/media/vfm/vframe.h>
 #include <linux/amlogic/media/video_sink/video.h>
 #include <linux/amlogic/media/video_sink/video_signal_notify.h>
@@ -2416,7 +2417,7 @@ void amdv_create_inst(void)
 			memset(dv_inst[i].comp_buf[1], 0, COMP_BUF_SIZE);
 
 		dv_inst[i].current_id = 0;
-		dv_inst[i].metadata_parser = NULL;
+		rcu_assign_pointer(dv_inst[i].metadata_parser, NULL);
 		dv_inst[i].layer_id = VD_PATH_MAX;
 		dv_inst[i].mapped = false;
 	}
@@ -2515,14 +2516,25 @@ int dv_inst_map(int *inst)
 		dv_inst[new_map_id].mapped = true;
 		*inst = new_map_id;
 
-		if (!dv_inst[*inst].metadata_parser && p_funcs_stb)
-			dv_inst[*inst].metadata_parser =
+		if (!rcu_dereference_protected(dv_inst[*inst].metadata_parser,
+					       lockdep_is_held(&dv_inst_lock)) &&
+		    p_funcs_stb) {
+			void *new_parser =
 				p_funcs_stb->multi_mp_init(dolby_vision_flags
 								& FLAG_CHANGE_SEQ_HEAD
 								? 1 : 0);
-		if (dv_inst[*inst].metadata_parser) {
-			p_funcs_stb->multi_mp_reset(dv_inst[*inst].metadata_parser, 1);
-			pr_dv_dbg("reset mp\n");
+			/* publish to vsync readers via RCU */
+			rcu_assign_pointer(dv_inst[*inst].metadata_parser,
+					   new_parser);
+		}
+		{
+			void *mp = rcu_dereference_protected
+				(dv_inst[*inst].metadata_parser,
+				 lockdep_is_held(&dv_inst_lock));
+			if (mp) {
+				p_funcs_stb->multi_mp_reset(mp, 1);
+				pr_dv_dbg("reset mp\n");
+			}
 		}
 		mutex_unlock(&dv_inst_lock);
 		/*clear dv_vf and framecount*/
@@ -2563,10 +2575,17 @@ void dv_inst_unmap(int inst)
 	if (dv_inst_valid(inst) && dv_inst[inst].mapped) {
 		dv_inst[inst].mapped = false;
 		last_unmap_id = inst;
-		if (dv_inst[inst].metadata_parser && p_funcs_stb) {
-			p_funcs_stb->multi_mp_release
-				(&dv_inst[inst].metadata_parser);
-			dv_inst[inst].metadata_parser = NULL;
+		{
+			void *parser = rcu_dereference_protected
+				(dv_inst[inst].metadata_parser,
+				 lockdep_is_held(&dv_inst_lock));
+			if (parser && p_funcs_stb) {
+				/* NULL first, drain in-flight vsync readers, then release */
+				rcu_assign_pointer
+					(dv_inst[inst].metadata_parser, NULL);
+				synchronize_rcu();
+				p_funcs_stb->multi_mp_release(&parser);
+			}
 		}
 		pr_info("%s %d OK\n", __func__, inst);
 	}
@@ -5902,16 +5921,29 @@ int parse_sei_and_meta_ext_v2(struct vframe_s *vf,
 				 &md_size,
 				 true);
 			} else {
-				rpu_ret =
-				p_funcs_stb->multi_mp_process
-				(dv_inst[dv_id].metadata_parser,
-				 meta_buf, rpu_size,
-				 comp_buf +
-				 *total_comp_size,
-				 &comp_size,
-				 md_buf + *total_md_size,
-				 &md_size,
-				 true, DV_TYPE_DOVI);
+				void *mp;
+
+				/* hold a live parser across multi_mp_process */
+				rcu_read_lock();
+				mp = rcu_dereference
+					(dv_inst[dv_id].metadata_parser);
+				if (!mp) {
+					/* torn down concurrently: contribute zero */
+					rcu_read_unlock();
+					rpu_ret = 0;
+				} else {
+					rpu_ret =
+					p_funcs_stb->multi_mp_process
+					(mp,
+					 meta_buf, rpu_size,
+					 comp_buf +
+					 *total_comp_size,
+					 &comp_size,
+					 md_buf + *total_md_size,
+					 &md_size,
+					 true, DV_TYPE_DOVI);
+					rcu_read_unlock();
+				}
 			}
 
 			if (rpu_ret < 0) {
@@ -6091,7 +6123,7 @@ int parse_sei_and_meta_ext_v2(struct vframe_s *vf,
 			md_size = 0;
 			comp_size = 0;
 
-			if (is_aml_tvmode())
+			if (is_aml_tvmode()) {
 				rpu_ret =
 				p_funcs_tv->metadata_parser_process
 				(meta_buf, size,
@@ -6100,16 +6132,29 @@ int parse_sei_and_meta_ext_v2(struct vframe_s *vf,
 				md_buf + *total_md_size,
 				&md_size,
 				true);
-			else
-				rpu_ret =
-				p_funcs_stb->multi_mp_process
-				(dv_inst[dv_id].metadata_parser,
-				 meta_buf, size,
-				 comp_buf + *total_comp_size,
-				 &comp_size,
-				 md_buf + *total_md_size,
-				 &md_size,
-				 true, DV_TYPE_ATSC);
+			} else {
+				void *mp;
+
+				/* hold a live parser across multi_mp_process */
+				rcu_read_lock();
+				mp = rcu_dereference
+					(dv_inst[dv_id].metadata_parser);
+				if (!mp) {
+					rcu_read_unlock();
+					rpu_ret = 0;
+				} else {
+					rpu_ret =
+					p_funcs_stb->multi_mp_process
+					(mp,
+					 meta_buf, size,
+					 comp_buf + *total_comp_size,
+					 &comp_size,
+					 md_buf + *total_md_size,
+					 &md_size,
+					 true, DV_TYPE_ATSC);
+					rcu_read_unlock();
+				}
+			}
 
 			if (rpu_ret < 0) {
 				pr_dv_error
@@ -14672,12 +14717,16 @@ int register_dv_functions(const struct dolby_vision_func_s *func)
 			/*where the decoder does not call the map and dv can also work normally.*/
 			/*Usually parser will be automatically created when play and map*/
 			for (i = 0; i < 2; i++) {
-				dv_inst[i].metadata_parser =
+				void *new_parser =
 				p_funcs_stb->multi_mp_init(dolby_vision_flags
 							   & FLAG_CHANGE_SEQ_HEAD
 							   ? 1 : 0);
-				p_funcs_stb->multi_mp_reset
-					(dv_inst[i].metadata_parser, 1);
+				rcu_assign_pointer
+					(dv_inst[i].metadata_parser,
+					 new_parser);
+				if (new_parser)
+					p_funcs_stb->multi_mp_reset
+						(new_parser, 1);
 			}
 
 			for (i = 0; i < new_m_dovi_setting.num_input; i++) {
@@ -14959,15 +15008,28 @@ int unregister_dv_functions(void)
 		}
 
 		if (multi_dv_mode) {
+			void *snapshots[NUM_INST] = { NULL };
+
+			/* two-pass: NULL all under lock, one synchronize_rcu, then release */
+			mutex_lock(&dv_inst_lock);
 			for (i = 0; i < NUM_INST; i++) {
-				if (dv_inst[i].metadata_parser && p_funcs_stb) {
-					p_funcs_stb->multi_mp_release
-						(&dv_inst[i].metadata_parser);
-					dv_inst[i].metadata_parser = NULL;
-				}
+				snapshots[i] = rcu_dereference_protected
+					(dv_inst[i].metadata_parser,
+					 lockdep_is_held(&dv_inst_lock));
+				if (snapshots[i])
+					rcu_assign_pointer
+						(dv_inst[i].metadata_parser,
+						 NULL);
 				if (dv_inst[i].mapped)
 					dv_inst[i].mapped = false;
 			}
+			synchronize_rcu();
+			for (i = 0; i < NUM_INST; i++) {
+				if (snapshots[i] && p_funcs_stb)
+					p_funcs_stb->multi_mp_release
+						(&snapshots[i]);
+			}
+			mutex_unlock(&dv_inst_lock);
 			if (new_m_dovi_setting.output_ctrl_data) {
 				vfree(new_m_dovi_setting.output_ctrl_data);
 				new_m_dovi_setting.output_ctrl_data = NULL;
@@ -17941,16 +18003,28 @@ static int __exit amdolby_vision_remove(struct platform_device *pdev)
 		vsem_md_buf = NULL;
 	}
 
-	for (i = 0; i < NUM_INST; i++) {
-		if (dv_inst[i].metadata_parser) {
-			if (p_funcs_stb && p_funcs_stb->multi_mp_release)
-				p_funcs_stb->multi_mp_release
-					(&dv_inst[i].metadata_parser);
-			else if (p_funcs_tv && p_funcs_tv->multi_mp_release)
-				p_funcs_tv->multi_mp_release
-					(&dv_inst[i].metadata_parser);
-			dv_inst[i].metadata_parser = NULL;
+	{
+		void *snapshots[NUM_INST] = { NULL };
+
+		/* two-pass RCU teardown (see unregister_dv_functions) */
+		for (i = 0; i < NUM_INST; i++) {
+			snapshots[i] = rcu_dereference_raw
+				(dv_inst[i].metadata_parser);
+			if (snapshots[i])
+				rcu_assign_pointer
+					(dv_inst[i].metadata_parser, NULL);
 		}
+		synchronize_rcu();
+		for (i = 0; i < NUM_INST; i++) {
+			if (!snapshots[i])
+				continue;
+			if (p_funcs_stb && p_funcs_stb->multi_mp_release)
+				p_funcs_stb->multi_mp_release(&snapshots[i]);
+			else if (p_funcs_tv && p_funcs_tv->multi_mp_release)
+				p_funcs_tv->multi_mp_release(&snapshots[i]);
+		}
+	}
+	for (i = 0; i < NUM_INST; i++) {
 		if (dv_inst[i].md_buf[0]) {
 			vfree(dv_inst[i].md_buf[0]);
 			dv_inst[i].md_buf[0] = NULL;

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -5390,7 +5390,7 @@ int parse_sei_and_meta_ext_v1(struct vframe_s *vf,
 		if (debug_dolby & 4)
 			pr_dv_dbg("metadata type=%08x, size=%d:\n",
 				     type, size);
-		if (size == 0 || size > aux_size) {
+		if (size == 0 || size > (unsigned int)(aux_buf + aux_size - p)) {
 			pr_dv_dbg("invalid aux size %d\n", size);
 			ret = 1;
 			goto parse_err;
@@ -5801,7 +5801,7 @@ int parse_sei_and_meta_ext_v2(struct vframe_s *vf,
 		if (debug_dolby & 4)
 			pr_dv_dbg("[inst%d]metadata type=%08x, size=%d:\n",
 				     dv_id + 1, type, size);
-		if (size == 0 || size > aux_size) {
+		if (size == 0 || size > (unsigned int)(aux_buf + aux_size - p)) {
 			pr_dv_dbg("invalid aux size %d\n", size);
 			ret = 1;
 			goto parse_err;

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -1914,7 +1914,8 @@ int amdv_update_setting(struct vframe_s *vf)
 	if (multi_dv_mode) {
 		if (vf && dv_inst_valid(vf->src_fmt.dv_id))
 			dv_id = vf->src_fmt.dv_id;
-		setting_update_count = dv_inst[dv_id].frame_count;
+		/* lone aligned field, no cross-field invariant -> marked read only */
+		setting_update_count = READ_ONCE(dv_inst[dv_id].frame_count);
 	} else if (is_aml_hw5()) {
 		setting_update_count = top2_v_info.frame_count;
 	} else {
@@ -2417,6 +2418,7 @@ void amdv_create_inst(void)
 			memset(dv_inst[i].comp_buf[1], 0, COMP_BUF_SIZE);
 
 		dv_inst[i].current_id = 0;
+		seqcount_init(&dv_inst[i].seq);
 		rcu_assign_pointer(dv_inst[i].metadata_parser, NULL);
 		dv_inst[i].layer_id = VD_PATH_MAX;
 		dv_inst[i].mapped = false;
@@ -2546,18 +2548,28 @@ int dv_inst_map(int *inst)
 			rcu_assign_pointer(dv_inst[*inst].metadata_parser,
 					   new_parser);
 		}
-		mutex_unlock(&dv_inst_lock);
 		/*clear dv_vf and framecount*/
 		amdv_clear_buf(*inst);
-		dv_inst[*inst].frame_count = 0;
-		dv_inst[*inst].last_mel_mode = 0;
-		dv_inst[*inst].last_total_md_size = 0;
-		dv_inst[*inst].last_total_comp_size = 0;
-		dv_inst[*inst].layer_id = VD_PATH_MAX;
-		dv_inst[*inst].video_height = 0;
-		dv_inst[*inst].video_width = 0;
-		dv_inst[*inst].valid = 0;
-		dv_inst[*inst].current_id = 0;
+		{
+			unsigned long __sf;
+
+			/* IRQs off so the vsync harvester cannot begin on this CPU
+			 * while seq is odd (livelock-free); write section is bounded
+			 * straight-line stores. amdv_clear_buf stays outside. */
+			local_irq_save(__sf);
+			write_seqcount_begin(&dv_inst[*inst].seq);
+			dv_inst[*inst].frame_count = 0;
+			dv_inst[*inst].last_mel_mode = 0;
+			dv_inst[*inst].last_total_md_size = 0;
+			dv_inst[*inst].last_total_comp_size = 0;
+			dv_inst[*inst].layer_id = VD_PATH_MAX;
+			dv_inst[*inst].video_height = 0;
+			dv_inst[*inst].video_width = 0;
+			dv_inst[*inst].valid = 0;
+			dv_inst[*inst].current_id = 0;
+			write_seqcount_end(&dv_inst[*inst].seq);
+			local_irq_restore(__sf);
+		}
 		/* size-before-pointer release: in_md==NULL implies in_md_size==0 */
 		WRITE_ONCE(dv_inst[*inst].src_format, FORMAT_SDR);
 		WRITE_ONCE(dv_inst[*inst].in_md_size, 0);
@@ -2566,6 +2578,7 @@ int dv_inst_map(int *inst)
 		WRITE_ONCE(dv_inst[*inst].in_md, NULL);
 		WRITE_ONCE(dv_inst[*inst].in_comp, NULL);
 		dv_inst[*inst].err_parse_cnt = 0;
+		mutex_unlock(&dv_inst_lock);
 		return 0;
 	}
 	mutex_unlock(&dv_inst_lock);
@@ -2632,7 +2645,11 @@ void force_unmap_all_inst(void)
 	/* hold dv_inst_lock across the field clears too, so a concurrent
 	 * dv_inst_map() cannot re-map and have its fresh fields clobbered */
 	for (i = 0; i < NUM_INST; i++) {
+		unsigned long __sf;
+
 		amdv_clear_buf(i);
+		local_irq_save(__sf);
+		write_seqcount_begin(&dv_inst[i].seq);
 		dv_inst[i].frame_count = 0;
 		dv_inst[i].last_mel_mode = 0;
 		dv_inst[i].last_total_md_size = 0;
@@ -2643,6 +2660,8 @@ void force_unmap_all_inst(void)
 		dv_inst[i].amdv_src_format = 0;
 		dv_inst[i].valid = 0;
 		dv_inst[i].current_id = 0;
+		write_seqcount_end(&dv_inst[i].seq);
+		local_irq_restore(__sf);
 		/* size-before-pointer release (see dv_inst_map) */
 		WRITE_ONCE(dv_inst[i].src_format, FORMAT_INVALID);
 		WRITE_ONCE(dv_inst[i].in_md_size, 0);
@@ -6321,8 +6340,14 @@ int parse_sei_and_meta(struct vframe_s *vf,
 			dv_inst[inst_id].last_total_comp_size = *total_comp_size;
 			dv_inst[inst_id].last_total_md_size = *total_md_size;
 		} else { /*parser err, use backup md and comp*/
-			*total_comp_size = dv_inst[inst_id].last_total_comp_size;
-			*total_md_size = dv_inst[inst_id].last_total_md_size;
+			unsigned int __eseq;
+
+			/* harvest the backup (comp,md) pair consistently vs re-init */
+			do {
+				__eseq = read_seqcount_begin(&dv_inst[inst_id].seq);
+				*total_comp_size = dv_inst[inst_id].last_total_comp_size;
+				*total_md_size = dv_inst[inst_id].last_total_md_size;
+			} while (read_seqcount_retry(&dv_inst[inst_id].seq, __eseq));
 		}
 	} else {
 		if (ret == 0) {
@@ -9820,10 +9845,17 @@ int amdv_parse_metadata_v2_stb(struct vframe_s *vf,
 				dv_inst[dv_id].last_mel_mode = mel_flag;
 			}
 		} else if (meta_flag_bl && meta_flag_el) {
-			total_md_size =  dv_inst[dv_id].last_total_md_size;
-			total_comp_size = dv_inst[dv_id].last_total_comp_size;
+			unsigned int __pseq;
+
+			/* Harvest the re-init batch consistently (md_size==0 below
+			 * drives a FORMAT_SDR fallback -- a torn read would flash). */
+			do {
+				__pseq = read_seqcount_begin(&dv_inst[dv_id].seq);
+				total_md_size = dv_inst[dv_id].last_total_md_size;
+				total_comp_size = dv_inst[dv_id].last_total_comp_size;
+				mel_flag = dv_inst[dv_id].last_mel_mode;
+			} while (read_seqcount_retry(&dv_inst[dv_id].seq, __pseq));
 			el_flag = dv_inst[dv_id].el_flag;
-			mel_flag = dv_inst[dv_id].last_mel_mode;
 			if (debug_dolby & 2)
 				pr_dv_dbg("update el_flag %d, melFlag %d\n",
 					     el_flag, mel_flag);
@@ -10827,10 +10859,21 @@ int amdv_control_path(struct vframe_s *vf, struct vframe_s *vf_2,
 		new_m_dovi_setting.input[i].valid = 1;
 		++valid_video_num;
 		if (dv_inst_valid(id)) {
+			u32 h_vw, h_vh;
+			unsigned int __cseq;
+
 			dv_inst[id].valid = 1;
 			input_mode = dv_inst[id].input_mode;
 			/* single snapshot, reused for the gate and the blob value */
 			src_format = READ_ONCE(dv_inst[id].src_format);
+			/* Harvest (video_width,video_height) as a consistent pair vs a
+			 * concurrent re-init, so the res-change compare + populate below
+			 * never see a torn width/height. */
+			do {
+				__cseq = read_seqcount_begin(&dv_inst[id].seq);
+				h_vw = dv_inst[id].video_width;
+				h_vh = dv_inst[id].video_height;
+			} while (read_seqcount_retry(&dv_inst[id].seq, __cseq));
 
 			if (new_m_dovi_setting.input[i].video_width &&
 			    new_m_dovi_setting.input[i].video_height) {
@@ -10848,14 +10891,14 @@ int amdv_control_path(struct vframe_s *vf, struct vframe_s *vf_2,
 				cur_input_mode = m_dovi_setting.input[i].input_mode;
 			}
 
-			if (new_m_dovi_setting.input[i].video_width != dv_inst[id].video_width ||
-			    new_m_dovi_setting.input[i].video_height != dv_inst[id].video_height) {
+			if (new_m_dovi_setting.input[i].video_width != h_vw ||
+			    new_m_dovi_setting.input[i].video_height != h_vh) {
 				res_change = true;
 				pr_dv_dbg("[inst%d vd%d]res changed %dx%d=> %dx%d\n",
 					  id + 1, i + 1,
 					  new_m_dovi_setting.input[i].video_width,
 					  new_m_dovi_setting.input[i].video_height,
-					  dv_inst[id].video_width, dv_inst[id].video_height);
+					  h_vw, h_vh);
 			}
 			if (i == 0 && inst_id_1 != last_inst_id_1) {
 				input_inst_change = true;
@@ -10888,8 +10931,8 @@ int amdv_control_path(struct vframe_s *vf, struct vframe_s *vf_2,
 				p_funcs_stb->multi_control_path(&invalid_m_dovi_setting);
 			}
 			new_m_dovi_setting.input[i].input_mode = dv_inst[id].input_mode;
-			new_m_dovi_setting.input[i].video_width = dv_inst[id].video_width;
-			new_m_dovi_setting.input[i].video_height = dv_inst[id].video_height;
+			new_m_dovi_setting.input[i].video_width = h_vw;
+			new_m_dovi_setting.input[i].video_height = h_vh;
 			smp_rmb(); /* acquire: pair with writer's src_format release */
 			new_m_dovi_setting.input[i].in_md =
 				READ_ONCE(dv_inst[id].in_md);

--- a/drivers/media/enhancement/amdolby_vision/amdv.h
+++ b/drivers/media/enhancement/amdolby_vision/amdv.h
@@ -12,6 +12,7 @@
 #define DRIVER_VER "202301225"
 
 #include <linux/types.h>
+#include <linux/seqlock.h>
 #include "amdv_pq_config.h"
 
 #define DOLBY_VISION_LL_DISABLE		0
@@ -611,6 +612,8 @@ struct dv_inst_s {
 	int vsem_if_size;
 	enum input_mode_enum input_mode;
 	u32 err_parse_cnt;
+	/* guards the process-ctx re-init store batch vs the vsync-IRQ harvesters */
+	seqcount_t seq;
 };
 
 /*hw5 video info*/

--- a/drivers/media/enhancement/amdolby_vision/amdv.h
+++ b/drivers/media/enhancement/amdolby_vision/amdv.h
@@ -588,7 +588,7 @@ struct dv_inst_s {
 	int amdv_wait_count;
 	bool amdv_wait_init;
 	bool dv_unique_drm;
-	void *metadata_parser;
+	void __rcu *metadata_parser;
 	bool mapped;
 	int layer_id;/*display on vd1 or vd2*/
 	int valid;

--- a/drivers/media/enhancement/amdolby_vision/amdv_pq_config.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv_pq_config.c
@@ -1582,6 +1582,8 @@ static bool get_one_line(char **cfg_buf, char *line_buf, bool ignore_comments)
 		} else {
 			line_len = (size_t)(line_end - *cfg_buf);
 		}
+		if (line_len > MAX_READ_SIZE - 1)
+			line_len = MAX_READ_SIZE - 1;
 		memcpy(line_buf, *cfg_buf, line_len);
 		line_buf[line_len] = '\0';
 		if (line_len > 0 && line_buf[line_len - 1] == '\r')
@@ -3652,6 +3654,8 @@ static bool read_one_line(char **text_buf, char *line_buf)
 		} else {
 			line_len = (size_t)(line_end - *text_buf);
 		}
+		if (line_len > MAX_READ_SIZE - 1)
+			line_len = MAX_READ_SIZE - 1;
 		memcpy(line_buf, *text_buf, line_len);
 		line_buf[line_len] = '\0';
 		if (line_len > 0 && line_buf[line_len - 1] == '\r')


### PR DESCRIPTION
Hardens the Amlogic Dolby Vision driver against several crashes and one cosmetic glitch. 

What it fixes:
- Crash when stopping or switching a Dolby Vision video
- Crash when seeking rapidly in a Dolby Vision movie
- A brief picture flash/shimmer while fast-seeking (no crash, just cosmetic)
- Out-of-bounds reads on malformed DV metadata and over-long config lines

Tested on an Ugoos AM6B Plus. The rapid-seek, play/stop, and teardown patterns that could panic the box look to behave better.