### PR TITLE
video/di: fix two buffer overruns and a PiP cleanup bug

### DIFF
--- a/drivers/media/di_multi/di_que_buf.c
+++ b/drivers/media/di_multi/di_que_buf.c
@@ -1254,7 +1254,7 @@ unsigned int qfp_list(struct qs_cls_s *p,
 
 	while (kfifo_out(&tmp_kfifo, &index, tst_quep_ele) ==
 	       tst_quep_ele && (cnt < size)) {
-		list[i] = (void *)index;
+		list[cnt] = (void *)index;
 		cnt++;
 	}
 	kfifo_free(&tmp_kfifo);

--- a/drivers/media/video_sink/video.c
+++ b/drivers/media/video_sink/video.c
@@ -5576,6 +5576,9 @@ static char *check_media_sei(char *sei, u32 sei_size, u32 fmt_type, u32 *ret_siz
 		type = (type << 8) | *p++;
 		type = (type << 8) | *p++;
 		type = (type << 8) | *p++;
+		/* block body must fit the remaining buffer (untrusted SEI length) */
+		if (size > (u32)(sei + sei_size - p))
+			break;
 		if (ret_size)
 			*ret_size = size + 8;
 		if ((sei_type == DV_SEI && sei_type == type)) {/*h264/h265 dv*/

--- a/drivers/media/video_sink/video_hw.c
+++ b/drivers/media/video_sink/video_hw.c
@@ -8612,7 +8612,7 @@ void vpp_blend_update(const struct vinfo_s *vinfo, u8 vpp_index)
 
 	if (!vd_layer[1].enabled && is_local_vf(vd_layer[1].dispbuf)) {
 		safe_switch_videolayer(1, false, true);
-		video_keeper_new_frame_notify(vd_layer[0].keep_frame_id);
+		video_keeper_new_frame_notify(vd_layer[1].keep_frame_id);
 	}
 
 	if (force_vpp_blend_update) {


### PR DESCRIPTION
Three small fixes:
- video: the per-frame HDR/DV SEI block size coming from the file was trusted, so a wrong or malicious size made the driver read past the end of the frame's data.
- di: the deinterlacer debug listing wrote one entry past the end of its array, scribbling on the stack. Only triggered when poking the debug info.
- video: closing the second video layer (picture-in-picture) released the main video's buffer instead of its own.