### PR TITLE
Allow Dolby Vision videos to be upscaled and played on 8K displays

### DIFF
--- a/drivers/media/enhancement/amvecm/amcsc.c
+++ b/drivers/media/enhancement/amvecm/amcsc.c
@@ -4080,13 +4080,11 @@ uint32_t sink_dv_support(const struct vinfo_s *vinfo)
 		if (!vinfo->vout_device->dv_info->sup_1080p120hz)
 			return 0;
 	}
-	/* currently all sink not support 4k100/120 and 8k dv */
+	/* currently all sink not support 4k100/120 dv */
 	if (strstr(vinfo->name, "2160p100hz") ||
 		strstr(vinfo->name, "2160p120hz") ||
 		strstr(vinfo->name, "3840x2160p100hz") ||
-		strstr(vinfo->name, "3840x2160p120hz") ||
-		strstr(vinfo->name, "7680x4320p")) {
-		/*in the future, some new flag in vsvdb will be used to judge dv cap*/
+		strstr(vinfo->name, "3840x2160p120hz")) {
 		return 0;
 	}
 	/* the display effect of 480/576p is not good on some TVs. */


### PR DESCRIPTION
## Summary
`sink_dv_support()` unconditionally reported no Dolby Vision capability whenever the current output mode's name contained `"7680x4320p"`, regardless of the sink's actual EDID capability. This blocked DV/LLDV signaling when displaying <=4K Dolby Vision content upscaled to an 8K output, even on sinks that correctly advertise DV support at 8K via VSVDB.

This removes that blanket 8K exclusion so DV capability is judged the same way for 8K output modes as for any other resolution. Content wider than 4096px (genuinely 8K-resolution decode) is unaffected — that path is separately gated by `support_8k_amdv()`, not touched here.

## Test plan
- [x] Tested on Ugoos SK1 (S928X-K, kernel 5.15.196), HDFury VRROOM and JVC DLA-RS4100: 4K Dolby Vision content displayed at 8K output resolution now correctly signals LLDV (12-bit 4:2:2) instead of silently falling back to plain HDR.
- [x] Confirmed no change in behavior for non-8K output resolutions.