### PR TITLE
drm/meson: add vblank_enabled tracking to am_meson_crtc

### DIFF
--- a/drivers/drm/meson_crtc.c
+++ b/drivers/drm/meson_crtc.c
@@ -540,11 +540,17 @@ static int meson_crtc_verify_crc_source(struct drm_crtc *crtc,
 
 static int meson_crtc_enable_vblank(struct drm_crtc *crtc)
 {
+	struct am_meson_crtc *amcrtc = to_am_meson_crtc(crtc);
+
+	amcrtc->vblank_enabled = true;
 	return 0;
 }
 
 static void meson_crtc_disable_vblank(struct drm_crtc *crtc)
 {
+	struct am_meson_crtc *amcrtc = to_am_meson_crtc(crtc);
+
+	amcrtc->vblank_enabled = false;
 }
 
 #ifdef CONFIG_DEBUG_FS

--- a/drivers/drm/meson_crtc.h
+++ b/drivers/drm/meson_crtc.h
@@ -122,6 +122,9 @@ struct am_meson_crtc {
 	/*present fence*/
 	struct am_meson_crtc_present_fence present_fence;
 
+	/*vblank*/
+	bool vblank_enabled;
+
 	/*commit*/
 	struct mutex commit_mutex;
 	atomic_t commit_num;


### PR DESCRIPTION
Track vblank enabled state in enable_vblank/disable_vblank callbacks so the DRM framework has proper feedback on vblank status. Previously these were empty stubs returning success without any state tracking.