### PR TITLE
Prefer YCbCr 4:2:2 during automatic HDMI colour format selection for 4K 50/60Hz modes

### DIFF
--- a/drivers/drm/meson_hdmi.c
+++ b/drivers/drm/meson_hdmi.c
@@ -350,7 +350,16 @@ static int meson_hdmitx_decide_color_attr
 			    strstr(common->fmt_attr, "422") == NULL &&
 			    strstr(common->fmt_attr, "444") == NULL) {
 				if (is_hdmi4k_support_420(vic & 0xff)) {
-					attr->colorformat = HDMI_COLORSPACE_YUV420;
+                       /*
+                        * Use YCbCr 4:2:2 when supported by the sink,
+                        * otherwise retain the existing YCbCr 4:2:0
+                        * behaviour.
+                        */
+                       if (common->rxcap.native_Mode & (1 << 4))
+                               attr->colorformat = HDMI_COLORSPACE_YUV422;
+                       else
+                               attr->colorformat = HDMI_COLORSPACE_YUV420;
+
 					DRM_INFO("[%s]: display colour subsampling is forced to %s because of current video information code %d\n", __func__,
 						colour_sampling[attr->colorformat], vic);
 				}


### PR DESCRIPTION
## Summary
When no explicit HDMI colour format is configured, the current implementation selects YCbCr 4:2:0 for UHD Video Identification Codes (VICs) that support 4:2:0 transmission.

This change prefers YCbCr 4:2:2 when the connected sink advertises support for it while preserving the existing YCbCr 4:2:0 behaviour for sinks that do not.

Explicitly configured HDMI colour formats are unchanged.

## Motivation
The current implementation always defaults to YCbCr 4:2:0 during automatic colour format selection for UHD modes, even when YCbCr 4:2:2 is available.

## Compatibility
No change for users who explicitly configure an HDMI colour format.
Existing YCbCr 4:2:0 behaviour is preserved when the sink does not advertise YCbCr 4:2:2 support.
Only automatic HDMI colour format selection for UHD modes is affected.
