### PR TITLE
amdv: out-of-bounds and use-after-free hardening

### DIFF
--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -2368,6 +2368,8 @@ void amdv_clear_buf(u8 dv_id)
 {
 	int i;
 	unsigned long flags;
+	struct vframe_s *el_put[16];
+	int el_num = 0;
 
 	spin_lock_irqsave(&amdv_lock, flags);
 
@@ -2381,21 +2383,30 @@ void amdv_clear_buf(u8 dv_id)
 					pr_dv_dbg("[inst%d]clear dv_vf %p\n",
 						     dv_id + 1, dv_inst[dv_id].dv_vf[i][0]);
 				dv_inst[dv_id].dv_vf[i][0] = NULL;
+				if (dv_inst[dv_id].dv_vf[i][1])
+					el_put[el_num++] = dv_inst[dv_id].dv_vf[i][1];
 				dv_inst[dv_id].dv_vf[i][1] = NULL;
 			}
 		}
 	} else if (is_aml_hw5()) {
 		for (i = 0; i < 16; i++) {
 			top2_v_info.dv_vf[i][0] = NULL;
+			if (top2_v_info.dv_vf[i][1])
+				el_put[el_num++] = top2_v_info.dv_vf[i][1];
 			top2_v_info.dv_vf[i][1] = NULL;
 		}
 	} else {
 		for (i = 0; i < 16; i++) {
 			dv_vf[i][0] = NULL;
+			if (dv_vf[i][1])
+				el_put[el_num++] = dv_vf[i][1];
 			dv_vf[i][1] = NULL;
 		}
 	}
 	spin_unlock_irqrestore(&amdv_lock, flags);
+
+	for (i = 0; i < el_num; i++)
+		dvel_vf_put(el_put[i]);
 }
 
 void amdv_create_inst(void)

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -15840,7 +15840,20 @@ static ssize_t amdolby_vision_debug_store
 	if (!buf)
 		return count;
 	buf_orig = kstrdup(buf, GFP_KERNEL);
+	if (!buf_orig)
+		return count;
 	parse_param_amdv(buf_orig, (char **)&parm);
+	if (!parm[0]) {
+		kfree(buf_orig);
+		return count;
+	}
+	{
+		int k;
+
+		for (k = 1; k < MAX_PARAM; k++)
+			if (!parm[k])
+				parm[k] = "";
+	}
 	if (!strcmp(parm[0], "amdv_crc")) {
 		if (kstrtoul(parm[1], 10, &val) < 0)
 			return -EINVAL;

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -16967,8 +16967,12 @@ static void parse_param(char *buf_orig, char **parm)
 			break;
 		if (*token == '\0')
 			continue;
+		if (n >= 8)
+			break;
 		parm[n++] = token;
 	}
+	while (n < 8)
+		parm[n++] = "";
 }
 
 static ssize_t amdolby_vision_reg_store

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -5905,6 +5905,8 @@ int parse_sei_and_meta_ext_v2(struct vframe_s *vf,
 						pr_dv_error("rpu in obu exceed 512 bytes\n");
 						break;
 					}
+					if (p + 13 + rpu_size > aux_buf + aux_size)
+						break;
 					for (i = 0; i < rpu_size; i++) {
 						meta_buf[5 + i] =
 							(p[12 + i] & 0x07) << 5;
@@ -5915,6 +5917,8 @@ int parse_sei_and_meta_ext_v2(struct vframe_s *vf,
 				} else {
 					rpu_size = (p[10] & 0x1f) << 3;
 					rpu_size |= (p[11] >> 5) & 0x07;
+					if (p + 12 + rpu_size > aux_buf + aux_size)
+						break;
 					for (i = 0; i < rpu_size; i++) {
 						meta_buf[5 + i] =
 							(p[11 + i] & 0x0f) << 4;

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -8952,21 +8952,25 @@ int amdv_parse_metadata_v1(struct vframe_s *vf,
 		    vinfo->vout_device->dv_info &&
 		    vinfo->vout_device->dv_info->ieeeoui == 0x00d046 &&
 		    vinfo->vout_device->dv_info->block_flag == CORRECT) {
+			u32 vsvdb_n = min_t(u32,
+				vinfo->vout_device->dv_info->length + 1,
+				sizeof(vinfo->vout_device->dv_info->rawdata));
+
 			if (new_dovi_setting.vsvdb_len
-				!= vinfo->vout_device->dv_info->length + 1)
+				!= vsvdb_n)
 				new_dovi_setting.vsvdb_changed = 1;
 			else if (memcmp
 				(&new_dovi_setting.vsvdb_tbl[0],
 				 &vinfo->vout_device->dv_info->rawdata[0],
-				 vinfo->vout_device->dv_info->length + 1))
+				 vsvdb_n))
 				new_dovi_setting.vsvdb_changed = 1;
 			memset(&new_dovi_setting.vsvdb_tbl[0],
 			       0, sizeof(new_dovi_setting.vsvdb_tbl));
 			memcpy(&new_dovi_setting.vsvdb_tbl[0],
 			       &vinfo->vout_device->dv_info->rawdata[0],
-			       vinfo->vout_device->dv_info->length + 1);
+			       vsvdb_n);
 			new_dovi_setting.vsvdb_len =
-				vinfo->vout_device->dv_info->length + 1;
+				vsvdb_n;
 			if (new_dovi_setting.vsvdb_changed &&
 			    new_dovi_setting.vsvdb_len) {
 				int k = 0;
@@ -10455,20 +10459,24 @@ int amdv_parse_metadata_v2_stb(struct vframe_s *vf,
 		    vinfo->vout_device->dv_info &&
 		    vinfo->vout_device->dv_info->ieeeoui == 0x00d046 &&
 		    vinfo->vout_device->dv_info->block_flag == CORRECT) {
+			u32 vsvdb_n = min_t(u32,
+				vinfo->vout_device->dv_info->length + 1,
+				sizeof(vinfo->vout_device->dv_info->rawdata));
+
 			if (new_m_dovi_setting.vsvdb_len
-				!= vinfo->vout_device->dv_info->length + 1)
+				!= vsvdb_n)
 				new_m_dovi_setting.vsvdb_changed = 1;
 			else if (memcmp(&new_m_dovi_setting.vsvdb_tbl[0],
 				&vinfo->vout_device->dv_info->rawdata[0],
-				vinfo->vout_device->dv_info->length + 1))
+				vsvdb_n))
 				new_m_dovi_setting.vsvdb_changed = 1;
 			memset(&new_m_dovi_setting.vsvdb_tbl[0],
 				0, sizeof(new_m_dovi_setting.vsvdb_tbl));
 			memcpy(&new_m_dovi_setting.vsvdb_tbl[0],
 				&vinfo->vout_device->dv_info->rawdata[0],
-				vinfo->vout_device->dv_info->length + 1);
+				vsvdb_n);
 			new_m_dovi_setting.vsvdb_len =
-				vinfo->vout_device->dv_info->length + 1;
+				vsvdb_n;
 			if (new_m_dovi_setting.vsvdb_changed &&
 			    new_m_dovi_setting.vsvdb_len) {
 				int k = 0;

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -2416,14 +2416,14 @@ void amdv_create_inst(void)
 	for (i = 0; i < NUM_INST; i++) {
 		dv_inst[i].md_buf[0] = vmalloc(MD_BUF_SIZE);
 		if (dv_inst[i].md_buf[0])
-			memset(dv_inst[0].md_buf[0], 0, MD_BUF_SIZE);
+			memset(dv_inst[i].md_buf[0], 0, MD_BUF_SIZE);
 		dv_inst[i].comp_buf[0] = vmalloc(COMP_BUF_SIZE);
 		if (dv_inst[i].comp_buf[0])
 			memset(dv_inst[i].comp_buf[0], 0, COMP_BUF_SIZE);
 
 		dv_inst[i].md_buf[1] = vmalloc(MD_BUF_SIZE);
 		if (dv_inst[i].md_buf[1])
-			memset(dv_inst[0].md_buf[1], 0, MD_BUF_SIZE);
+			memset(dv_inst[i].md_buf[1], 0, MD_BUF_SIZE);
 		dv_inst[i].comp_buf[1] = vmalloc(COMP_BUF_SIZE);
 		if (dv_inst[i].comp_buf[1])
 			memset(dv_inst[i].comp_buf[1], 0, COMP_BUF_SIZE);

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -15072,7 +15072,7 @@ int unregister_dv_functions(void)
 		if (is_aml_hw5()) {
 			if (pq_config_dvp_fake) {
 				vfree(pq_config_dvp_fake);
-				pq_config_fake = NULL;
+				pq_config_dvp_fake = NULL;
 			}
 			if (tv_hw5_setting) {
 				vfree(tv_hw5_setting);

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -14421,7 +14421,20 @@ static ssize_t amdolby_vision_load_reg_file_store
 	if (!buf)
 		return count;
 	buf_orig = kstrdup(buf, GFP_KERNEL);
+	if (!buf_orig)
+		return count;
 	parse_param_amdv(buf_orig, (char **)&parm);
+	if (!parm[0]) {
+		kfree(buf_orig);
+		return count;
+	}
+	{
+		int k;
+
+		for (k = 1; k < MAX_PARAM; k++)
+			if (!parm[k])
+				parm[k] = "";
+	}
 	pr_info("%s: cmd: %s, %s\n", __func__, buf, parm[1]);
 
 	if (!strcmp(parm[0], "top1_reg")) {
@@ -14598,6 +14611,7 @@ static ssize_t amdolby_vision_load_reg_file_store
 		vfree(top1_pic_txt);
 	if (top1_pic_uv_txt)
 		vfree(top1_pic_uv_txt);
+	kfree(buf_orig);
 	return count;
 }
 

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -6109,8 +6109,12 @@ int parse_sei_and_meta_ext_v2(struct vframe_s *vf,
 
 				if (nal_type == PREFIX_SEI_NUT_NAL ||
 					nal_type == SUFFIX_SEI_NUT_NAL) {
+					if (p + 4 > aux_buf + aux_size)
+						break;
 					sei_payload_type = *(p + 2);
 					sei_payload_size = *(p + 3);
+					if (p + 4 + sei_payload_size > aux_buf + aux_size)
+						break;
 					if (debug_dolby & 2)
 						pr_dv_dbg("type %d, size %d\n",
 							     sei_payload_type,

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -5095,17 +5095,21 @@ void amdv_vf_put(struct vframe_s *vf)
 {
 	int i;
 	int dv_id = 0;
+	struct vframe_s *el_put[16];
+	int el_num = 0;
+	unsigned long flags;
 
 	if (!vf)
 		return;
 
+	spin_lock_irqsave(&amdv_lock, flags);
 	if (multi_dv_mode) {
 		if (vf && dv_inst_valid(vf->src_fmt.dv_id))
 			dv_id = vf->src_fmt.dv_id;
 		for (i = 0; i < 16; i++) {
 			if (dv_inst[dv_id].dv_vf[i][0] == vf) {
 				if (dv_inst[dv_id].dv_vf[i][1]) {
-					dvel_vf_put(dv_inst[dv_id].dv_vf[i][1]);
+					el_put[el_num++] = dv_inst[dv_id].dv_vf[i][1];
 				} else if (debug_dolby & 2) {
 					pr_dv_dbg("--#%d: put bl(%p-%lld) --\n",
 						     dv_id, vf, vf->pts_us64);
@@ -5123,7 +5127,7 @@ void amdv_vf_put(struct vframe_s *vf)
 							vf, vf->pts_us64,
 							top2_v_info.dv_vf[i][1],
 							top2_v_info.dv_vf[i][1]->pts_us64);
-					dvel_vf_put(top2_v_info.dv_vf[i][1]);
+					el_put[el_num++] = top2_v_info.dv_vf[i][1];
 				} else if (debug_dolby & 2) {
 					pr_dv_dbg("--- put bl(%p-%lld) ---\n",
 						vf, vf->pts_us64);
@@ -5141,7 +5145,7 @@ void amdv_vf_put(struct vframe_s *vf)
 							vf, vf->pts_us64,
 							dv_vf[i][1],
 							dv_vf[i][1]->pts_us64);
-					dvel_vf_put(dv_vf[i][1]);
+					el_put[el_num++] = dv_vf[i][1];
 				} else if (debug_dolby & 2) {
 					pr_dv_dbg("--- put bl(%p-%lld) ---\n",
 						vf, vf->pts_us64);
@@ -5151,6 +5155,11 @@ void amdv_vf_put(struct vframe_s *vf)
 			}
 		}
 	}
+
+	spin_unlock_irqrestore(&amdv_lock, flags);
+
+	for (i = 0; i < el_num; i++)
+		dvel_vf_put(el_put[i]);
 }
 EXPORT_SYMBOL(amdv_vf_put);
 

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -14870,14 +14870,14 @@ int register_dv_functions(const struct dolby_vision_func_s *func)
 				return -ENOMEM;
 			pq_config_dvp_fake =
 				(struct pq_config *)pq_cfg_dvp;
-			tv_hw5_setting = vmalloc(sizeof(*tv_hw5_setting));
+			tv_hw5_setting = vzalloc(sizeof(*tv_hw5_setting));
 			if (!tv_hw5_setting) {
 				vfree(pq_config_dvp_fake);
 				pq_config_dvp_fake = NULL;
 				p_funcs_tv = NULL;
 				return -ENOMEM;
 			}
-			invalid_hw5_setting = vmalloc(sizeof(*invalid_hw5_setting));
+			invalid_hw5_setting = vzalloc(sizeof(*invalid_hw5_setting));
 			if (!invalid_hw5_setting) {
 				vfree(pq_config_dvp_fake);
 				pq_config_dvp_fake = NULL;
@@ -14886,7 +14886,7 @@ int register_dv_functions(const struct dolby_vision_func_s *func)
 				p_funcs_tv = NULL;
 				return -ENOMEM;
 			}
-			last_tv_hw5_setting = vmalloc(sizeof(*last_tv_hw5_setting));
+			last_tv_hw5_setting = vzalloc(sizeof(*last_tv_hw5_setting));
 			if (!last_tv_hw5_setting) {
 				vfree(pq_config_dvp_fake);
 				pq_config_dvp_fake = NULL;

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -7539,6 +7539,7 @@ int vsem_check(unsigned char *control_data, unsigned char *vsem_payload)
 	int rv = 0;
 	u32 crc;
 	u32 data_length = 0;
+	u32 last_len;
 	bool last = false;
 
 	cur_pkt = (struct vsem_data_pkt *)(control_data);
@@ -7549,14 +7550,19 @@ int vsem_check(unsigned char *control_data, unsigned char *vsem_payload)
 		return rv;
 	}
 	data_length = get_data_len(cur_pkt);
+	if (data_length < 6 || data_length > VSEM_BUF_SIZE - 7)
+		return -1;
 	memcpy(p_buf, &cur_pkt->pb[0], VSEM_PKT_BODY_SIZE);
 	cur_len = VSEM_PKT_BODY_SIZE - 7;
 	p_buf += VSEM_PKT_BODY_SIZE;
 	while (!last) {
 		cur_pkt += 1;
 		if (get_vsem_byte(cur_pkt->hb1, HEADER_MASK_LAST)) {
-			memcpy(p_buf, &cur_pkt->pb[0],
-				data_length - cur_len);
+			last_len = (data_length > cur_len) ?
+				data_length - cur_len : 0;
+			if (last_len > VSEM_PKT_BODY_SIZE)
+				last_len = VSEM_PKT_BODY_SIZE;
+			memcpy(p_buf, &cur_pkt->pb[0], last_len);
 			last = true;
 		} else {
 			memcpy(p_buf, &cur_pkt->pb[0],

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -10808,6 +10808,9 @@ int amdv_control_path(struct vframe_s *vf, struct vframe_s *vf_2,
 		new_m_dovi_setting.input[i].el_flag = 0;
 		new_m_dovi_setting.input[i].in_md_size = 0;
 		new_m_dovi_setting.input[i].in_comp_size = 0;
+		new_m_dovi_setting.input[i].in_md = NULL;
+		new_m_dovi_setting.input[i].in_comp = NULL;
+		new_m_dovi_setting.input[i].el_halfsize_flag = 0;
 	}
 	for (i = 0; i < NUM_INST; i++)
 		dv_inst[i].valid = 0;

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -2172,6 +2172,8 @@ void dv_vf_light_unreg_provider(void)
 {
 	int i;
 	unsigned long flags;
+	struct vframe_s *el_put[16];
+	int el_num = 0;
 
 	spin_lock_irqsave(&amdv_lock, flags);
 	if (vfm_path_on) {
@@ -2190,7 +2192,7 @@ void dv_vf_light_unreg_provider(void)
 			for (i = 0; i < 16; i++) {
 				if (dv_vf[i][0]) {
 					if (dv_vf[i][1])
-						dvel_vf_put(dv_vf[i][1]);
+						el_put[el_num++] = dv_vf[i][1];
 					dv_vf[i][1] = NULL;
 				}
 				dv_vf[i][0] = NULL;
@@ -2208,6 +2210,9 @@ void dv_vf_light_unreg_provider(void)
 	}
 	vfm_path_on = false;
 	spin_unlock_irqrestore(&amdv_lock, flags);
+
+	for (i = 0; i < el_num; i++)
+		dvel_vf_put(el_put[i]);
 }
 EXPORT_SYMBOL(dv_vf_light_unreg_provider);
 

--- a/drivers/media/enhancement/amdolby_vision/amdv.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv.c
@@ -14723,8 +14723,12 @@ int register_dv_functions(const struct dolby_vision_func_s *func)
 			if (is_aml_tm2() || is_aml_t7()) {
 				tv_dovi_setting =
 				vmalloc(sizeof(struct tv_dovi_setting_s));
-				if (!tv_dovi_setting)
+				if (!tv_dovi_setting) {
+					vfree(ko_info);
+					ko_info = NULL;
+					p_funcs_stb = NULL;
 					return -ENOMEM;
+				}
 			}
 			hdmi_source_led_as_hdr10 = true;
 			enable_multi_core1 = 0;
@@ -14821,6 +14825,7 @@ int register_dv_functions(const struct dolby_vision_func_s *func)
 			if (!new_m_dovi_setting.output_ctrl_data) {
 				vfree(ko_info);
 				ko_info = NULL;
+				p_funcs_stb = NULL;
 				pr_info("output_ctrl_data malloc error\n");
 				return -ENOMEM;
 			}
@@ -14852,6 +14857,7 @@ int register_dv_functions(const struct dolby_vision_func_s *func)
 				if (!tv_dovi_setting) {
 					vfree(ko_info);
 					ko_info = NULL;
+					p_funcs_stb = NULL;
 					pr_info("tv setting malloc error\n");
 					return -ENOMEM;
 				}

--- a/drivers/media/enhancement/amdolby_vision/amdv_hw5_process.c
+++ b/drivers/media/enhancement/amdolby_vision/amdv_hw5_process.c
@@ -488,7 +488,7 @@ int parse_sei_and_meta_ext_hw5(struct vframe_s *vf,
 		if (debug_dolby & 4)
 			pr_dv_dbg("metadata type=%08x, size=%d:\n",
 				     type, size);
-		if (size == 0 || size > aux_size) {
+		if (size == 0 || size > (aux_buf + aux_size - p)) {
 			pr_dv_dbg("invalid aux size %d\n", size);
 			ret = 1;
 			goto parse_err;


### PR DESCRIPTION
A batch of small safety fixes for the amdolby_vision driver. I went through the metadata, EDID and sysfs parsing paths plus the video-frame handling and cleaned up the spots that could read or write past a buffer, free something twice, or use a pointer after it was gone. None of these change how the driver behaves. 
  