### PR TITLE
drm/hdmi: fix Dolby Vision colour base at decide time

### DIFF
--- a/drivers/drm/meson_hdmi.c
+++ b/drivers/drm/meson_hdmi.c
@@ -455,6 +455,22 @@ static int meson_hdmitx_decide_color_attr
 			break;
 	}
 
+	if (is_amdv_enable() &&
+	    common->hdmi_current_eotf_type != EOTF_T_DOLBYVISION &&
+	    common->hdmi_current_eotf_type != EOTF_T_LL_MODE &&
+	    common->hdmi_current_eotf_type != EOTF_T_DV_AHEAD) {
+		if (get_amdv_ll_policy() == DOLBY_VISION_LL_YUV422) {
+			attr->colorformat = HDMI_COLORSPACE_YUV422;
+			attr->bitdepth = colordepth_to_bitdepth(COLORDEPTH_36B);
+		} else {
+			attr->colorformat = HDMI_COLORSPACE_YUV444;
+			attr->bitdepth = colordepth_to_bitdepth(COLORDEPTH_24B);
+		}
+		DRM_INFO("[%s]: DV base pinned to %s %dbit (ll_policy %d) for vic %d\n",
+			__func__, colour_sampling[attr->colorformat], attr->bitdepth,
+			get_amdv_ll_policy(), vic);
+	}
+
 	DRM_INFO("[%s]:[%s,eotf:%d,vic:%d]=>attr[%s,%dbit]\n", __func__,
 		outputmode, common->hdmi_current_eotf_type, vic,
 		colour_sampling[attr->colorformat], attr->bitdepth);

--- a/include/linux/amlogic/media/amdolbyvision/dolby_vision.h
+++ b/include/linux/amlogic/media/amdolbyvision/dolby_vision.h
@@ -205,6 +205,11 @@ void update_graphic_width_height(unsigned int width,
 	unsigned int height, enum OSD_INDEX index);
 int get_amdv_policy(void);
 void set_amdv_policy(int policy);
+#ifndef DOLBY_VISION_LL_DISABLE
+#define DOLBY_VISION_LL_DISABLE		0
+#define DOLBY_VISION_LL_YUV422		1
+#define DOLBY_VISION_LL_RGB444		2
+#endif
 int get_amdv_ll_policy(void);
 int get_amdv_src_format(enum vd_path_e vd_path);
 bool is_amdv_el_disable(void);


### PR DESCRIPTION
decide_color_attr picks the colour base from hdmi_current_eotf_type, but for Dolby Vision that is not set yet when the mode is committed (the DV core sets it later over VSIF). So a DV title gets an SDR base: no signal at 4K60, and the wrong depth after a 24/23.976 switch.

is_amdv_enable() and get_amdv_ll_policy() are already valid here, so use them to pin the tunnel base for any 4K vic: TV-led is YUV444 8-bit, player-led is YUV422 12-bit. SDR and HDR10 are left alone.

Needs the matching xbmc change to force the re-decide.